### PR TITLE
Allow nvim as an editor

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,14 +63,29 @@ env SICHER_MASTER_KEY=`{YOUR_KEY_HERE}` sicher edit
 
 **_Optional flags:_**
 
-| flag    | description                                     | default | options             |
-| ------- | ----------------------------------------------- | ------- | ------------------- |
-| -env    | set the environment name                        | dev     |                     |
-| -path   | set the path to the credentials file            | .       |                     |
-| -editor | set the editor to use                           | vim     | vim, nano, vi, code |
-| -style  | set the style of the decrypted credentials file | dotenv  | dotenv or yaml      |
+| flag    | description                                     | default | options        |
+| ------- | ----------------------------------------------- | ------- | -------------- |
+| -env    | set the environment name                        | dev     |                |
+| -path   | set the path to the credentials file            | .       |                |
+| -editor | set the editor to use                           | vim     |                |
+| -style  | set the style of the decrypted credentials file | dotenv  | dotenv or yaml |
 
 This will create a temporary file, decrypt the credentials into it, and open it in your editor. The editor defaults to `vim`, but can be also set to other editors with the `-editor` flag. The temporary file is destroyed after each save, and the encrypted credentials file is updated with the new content.
+
+Known good editors are:
+
+- code
+- emacs
+- gvim
+- mvim
+- nano
+- nvim
+- subl
+- vi
+- vim
+- vimr
+
+Graphical editors require a flag to instruct the CLI to wait for the editor to exit. Additional graphical editors can be supported by adding the binary name and flag to the `waitFlagMap` in `sicher.go`. Most CLI editors should work out of the box, but your mileage may vary.
 
 Then in your app, you can use the `sicher` library to load the credentials:
 

--- a/cli/sicher.go
+++ b/cli/sicher.go
@@ -32,7 +32,7 @@ func init() {
 	flag.StringVar(&pathFlag, "path", ".", "Path to the project")
 	flag.StringVar(&envFlag, "env", "dev", "Environment to use")
 	flag.StringVar(&styleFlag, "style", string(sicher.DefaultEnvStyle), "Env file style. Valid values are dotenv and yaml")
-	flag.StringVar(&editorFlag, "editor", "vim", "Select editor. vim | vi | nano | code")
+	flag.StringVar(&editorFlag, "editor", "vim", "Select editor.")
 	flag.StringVar(&gitignorePathFlag, "gitignore", ".", "Path to the gitignore file")
 
 	flag.ErrHelp = errors.New(errHelp)

--- a/sicher.go
+++ b/sicher.go
@@ -160,7 +160,7 @@ func (s *sicher) Edit(editor ...string) error {
 		editorName = "vim"
 	}
 
-	match, _ := regexp.MatchString("^(nano|n?vim|vi|code|)$", editorName)
+	match, _ := regexp.MatchString("^(nano|n?vim?|code|)$", editorName)
 	if !match {
 		return fmt.Errorf("invalid Command: Select one of vim, vi, code or nano as editor, or leave as empty")
 	}

--- a/sicher.go
+++ b/sicher.go
@@ -160,7 +160,7 @@ func (s *sicher) Edit(editor ...string) error {
 		editorName = "vim"
 	}
 
-	match, _ := regexp.MatchString("^(nano|vim|vi|code|)$", editorName)
+	match, _ := regexp.MatchString("^(nano|n?vim|vi|code|)$", editorName)
 	if !match {
 		return fmt.Errorf("invalid Command: Select one of vim, vi, code or nano as editor, or leave as empty")
 	}

--- a/sicher.go
+++ b/sicher.go
@@ -15,7 +15,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"regexp"
 
 	"github.com/juju/fslock"
 )
@@ -30,6 +29,14 @@ var (
 	stdOut  io.ReadWriter = os.Stdout
 	stdErr  io.ReadWriter = os.Stderr
 )
+
+var waitFlagmap = map[string]string{
+	"code": "--wait",
+	"gvim": "-f",
+	"mvim": "-f",
+	"subl": "--wait",
+	"vimr": "--wait",
+}
 
 type sicher struct {
 	// Path is the path to the project. If empty string, it defaults to the current directory
@@ -160,16 +167,12 @@ func (s *sicher) Edit(editor ...string) error {
 		editorName = "vim"
 	}
 
-	match, _ := regexp.MatchString("^(nano|n?vim?|code|)$", editorName)
-	if !match {
-		return fmt.Errorf("invalid Command: Select one of vim, vi, code or nano as editor, or leave as empty")
-	}
-
 	var cmdArgs []string
+
 	// waitOpt is needed to enable vscode to wait for the editor to close before continuing
-	var waitOpt string
-	if editorName == "code" {
-		waitOpt = "--wait"
+	waitOpt, ok := waitFlagmap[editorName]
+
+	if ok {
 		cmdArgs = append(cmdArgs, waitOpt)
 	}
 

--- a/sicher_test.go
+++ b/sicher_test.go
@@ -169,6 +169,84 @@ func TestEditFail(t *testing.T) {
 	}
 }
 
+func TestEditAddsWaitFlag(t *testing.T) {
+	oldExecCmd := execCmd
+	defer func() { execCmd = oldExecCmd }()
+	s, encPath, keyPath := setupTest()
+
+	s.Initialize(os.Stdin)
+	buf := bytes.Buffer{}
+
+	editors := []string{"code", "subl", "vimr"}
+
+	for _, editor := range editors {
+		execCmd = func(cmd string, args ...string) *exec.Cmd {
+			t.Log(cmd, args)
+			stdIn, stdOut, stdErr = &buf, &buf, &buf
+
+			if cmd != editor {
+				t.Errorf("Expected command to be %s, got %s", editor, cmd)
+			}
+
+			if args[0] != "--wait" {
+				t.Errorf("Expected args to include --wait")
+			}
+
+			return exec.Command("cat", args...)
+		}
+
+		s.Edit(editor)
+
+		// get path to the gitignore file and cleanup
+		gitPath := strings.Replace(encPath, fmt.Sprintf("%s.enc", s.Environment), ".gitignore", 1)
+
+		t.Cleanup(func() {
+			os.Remove(encPath)
+			os.Remove(keyPath)
+			os.Remove(gitPath)
+		})
+	}
+}
+
+func TestEditAddsFFlag(t *testing.T) {
+	oldExecCmd := execCmd
+	defer func() { execCmd = oldExecCmd }()
+	s, encPath, keyPath := setupTest()
+
+	s.Initialize(os.Stdin)
+	buf := bytes.Buffer{}
+
+	editors := []string{"mvim", "gvim"}
+
+	for _, editor := range editors {
+		execCmd = func(cmd string, args ...string) *exec.Cmd {
+			t.Log(cmd, args)
+			stdIn, stdOut, stdErr = &buf, &buf, &buf
+
+			if cmd != editor {
+				t.Errorf("Expected command to be %s, got %s", editor, cmd)
+			}
+
+			if args[0] != "-f" {
+				t.Errorf("Expected args to include -f")
+			}
+
+			return exec.Command("cat", args...)
+		}
+
+		s.Edit(editor)
+
+		// get path to the gitignore file and cleanup
+		gitPath := strings.Replace(encPath, fmt.Sprintf("%s.enc", s.Environment), ".gitignore", 1)
+
+		t.Cleanup(func() {
+			os.Remove(encPath)
+			os.Remove(keyPath)
+			os.Remove(gitPath)
+		})
+	}
+}
+
 func TestSicherInitialize(t *testing.T) {
 
 	s, encPath, keyPath := setupTest()


### PR DESCRIPTION
The regex for determining the editor was a little bit too restrictive. I'm curious why this restriction on editors exists, though. It seems like any valid text editor should work here. I commented this block out and was able to use most other editors I tried. If you are open to it, I think I can make this much more robust.